### PR TITLE
Fix verify script when catalog folder missing

### DIFF
--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -32,4 +32,10 @@ await fs.writeFile(
   path.join(BUILD_DIR, 'catalog.json'),
   JSON.stringify({ albums, playlists }, null, 2)
 );
+// during development we serve the player/ directory directly so copy
+// the generated index for convenience
+await fs.copyFile(
+  path.join(BUILD_DIR, 'catalog.json'),
+  path.join('player', 'catalog.json')
+);
 console.log('✓ build/catalog.json generated');

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 # Simple sanity checks: missing YAML, duplicate catalog numbers, etc.
-set -e
+set -euo pipefail
 echo "Running catalog verifier.."
+
+# skip if the optional catalog/ directory is absent
+if [ ! -d catalog ]; then
+  echo "catalog/ directory not found; skipping checks"
+  exit 0
+fi
+
 dupes=$(grep -rh "^catalog:" catalog | cut -d' ' -f2 | sort | uniq -d)
 if [ -n "$dupes" ]; then
   echo "Duplicate catalog numbers: $dupes"


### PR DESCRIPTION
## Summary
- avoid failing when running `verify.sh` with no catalog/ directory
- copy generated catalog index into the player folder for convenience

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_686ba1333b948331bea2552951217da0