### PR TITLE
Fix src paths in catalog build script

### DIFF
--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -17,7 +17,7 @@ async function walkCatalog() {
       // convert track file → full src path
       meta.tracks = meta.tracks.map(t => ({
         ...t,
-        src: `${folder}/${t.file}`
+        src: `${CATALOG_DIR}/${folder}/${t.file}`
       }));
       albums.push(meta);
     } catch (err) {


### PR DESCRIPTION
## Summary
- include `catalog/` prefix when generating track paths

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_686ba2ee9a1c8331a40adece32cd0712