### PR TITLE
Add WAV file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ repo-root/
 │   └─ 2025-07-demo-album/
 │       ├─ cover.jpg
 │       ├─ 01-track1.mp3
-│       ├─ 02-track2.mp3
+│       ├─ 02-track2.wav
 │       └─ album.yaml
 │
 ├─ scripts/
@@ -50,7 +50,7 @@ npm run dev            # builds catalog.json + serves site on http://localhost:8
 ## ➕ Adding a new release
 
 1. Create `catalog/YYYY-MM-album-slug/`
-2. Copy audio files (`01-track.mp3` …) and `cover.jpg`
+2. Copy audio files (`01-track.mp3` or `01-track.wav` …) and `cover.jpg`
 3. Write `album.yaml`
 4. `git add . && git commit`
 

--- a/scripts/optimize-audio.sh
+++ b/scripts/optimize-audio.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Quick loudness normalisation example using ffmpeg
-# Usage: ./scripts/optimize-audio.sh catalog/2025-07-demo-album/*.mp3
+# Usage: ./scripts/optimize-audio.sh catalog/2025-07-demo-album/*.{mp3,wav}
 set -e
 for f in "$@"; do
   echo "Processing $f"
-  ffmpeg -hide_banner -loglevel error -i "$f" -af loudnorm=I=-14:TP=-1.5:LRA=11 -y "${f%.mp3}-norm.mp3"
+  ext="${f##*.}"
+  ffmpeg -hide_banner -loglevel error -i "$f" -af loudnorm=I=-14:TP=-1.5:LRA=11 -y "${f%.$ext}-norm.$ext"
 done


### PR DESCRIPTION
## Summary
- handle missing `catalog/` folder in build script
- detect `.mp3` or `.wav` extensions when missing in `album.yaml`
- improve optimize-audio script to support mp3 or wav files
- note WAV file usage in README

## Testing
- `npm run verify`
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ba44e991c8331baa60dc50deaa87e