### PR TITLE
Improve README instructions for dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ repo-root/
 git clone <repo-url> && cd <repo>
 npm ci
 npm run dev            # builds catalog.json, serves site on http://localhost:8080/player
+# (run from the repo root so /catalog is served)
+
+# or run live-server manually from the repo root
+# npx live-server --open=player
 ```
 
 ## ➕ Adding a new release
@@ -55,3 +59,7 @@ npm run dev            # builds catalog.json, serves site on http://localhost:80
 4. `git add . && git commit`
 
 CI / `npm run build` regenerates `build/catalog.json` for the player.
+## ❓ Troubleshooting
+If the player shows '?' icons instead of album art or audio won't play,
+make sure `live-server` is started from the repository root so the `catalog/` folder is served.
+


### PR DESCRIPTION
## Summary
- clarify that `npm run dev` must be run from repo root
- add troubleshooting tips when covers or audio fail to load

## Testing
- `npm run build`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_686baad02134833180c921b124611bbf