### PR TITLE
Add artist navigation and now playing info

### DIFF
--- a/player/index.html
+++ b/player/index.html
@@ -20,6 +20,7 @@
 
   <div id="player" class="w-full max-w-lg bg-white border border-black p-6 shadow-sm">
     <!-- lists -->
+    <ul id="artistList" class="artist-list mb-4 max-h-40 overflow-y-auto divide-y divide-black"></ul>
     <ul id="albumList" class="album-list mb-4 max-h-40 overflow-y-auto divide-y divide-black"></ul>
     <ul id="playlistList" class="playlist-list mb-4 max-h-40 overflow-y-auto divide-y divide-black"></ul>
     <img id="coverImg" alt="Album cover" class="w-full mb-4 hidden" />
@@ -31,6 +32,7 @@
       <button id="playPauseBtn" aria-label="Play / Pause" class="p-1 hover:bg-black hover:text-white transition">▶️</button>
       <button id="nextBtn" aria-label="Next track" class="p-1 hover:bg-black hover:text-white transition">⏭</button>
     </div>
+    <div id="nowPlaying" class="text-center mb-2"></div>
     <progress id="seekBar" value="0" max="100" aria-label="Playback position"></progress>
     <audio id="audio"></audio>
   </div>
@@ -43,6 +45,7 @@
     ========================================================= */
     let albums = [];
     let playlists = [];
+    let artists = [];
 
     fetch('catalog.json')
       .then(r => {
@@ -52,6 +55,7 @@
       .then(data => {
         albums = data.albums || [];
         playlists = data.playlists || [];
+        artists = data.artists || [];
         boot();
       })
       .catch(err => {
@@ -64,6 +68,7 @@
        DOM refs
     ========================================================= */
     const albumListEl = document.getElementById("albumList");
+    const artistListEl = document.getElementById("artistList");
     const playlistListEl = document.getElementById("playlistList");
     const trackListEl = document.getElementById("trackList");
     const audioEl = document.getElementById("audio");
@@ -72,6 +77,7 @@
     const nextBtn = document.getElementById("nextBtn");
     const seekBar = document.getElementById("seekBar");
     const coverImg = document.getElementById("coverImg");
+    const nowPlayingEl = document.getElementById("nowPlaying");
 
     /* =========================================================
        State
@@ -94,6 +100,17 @@
       });
     }
 
+    function renderArtists() {
+      artistListEl.innerHTML = '';
+      artists.forEach((artist, idx) => {
+        const li = document.createElement('li');
+        li.textContent = '🎤 ' + artist.name;
+        li.className = 'px-2 py-2 cursor-pointer hover:bg-black/5';
+        li.onclick = () => loadArtist(idx);
+        artistListEl.appendChild(li);
+      });
+    }
+
     function renderPlaylists() {
       playlistListEl.innerHTML = '';
       playlists.forEach((pl, idx) => {
@@ -108,6 +125,8 @@
     function loadAlbum(i) {
       currentList = albums[i].tracks;
       highlight(albumListEl, i);
+      highlight(artistListEl, -1);
+      highlight(playlistListEl, -1);
       if (albums[i].cover) {
         coverImg.src = albums[i].cover;
         coverImg.classList.remove('hidden');
@@ -119,9 +138,22 @@
       loadTrack(0);
     }
 
+    function loadArtist(i) {
+      currentList = artists[i].tracks;
+      highlight(artistListEl, i);
+      highlight(albumListEl, -1);
+      highlight(playlistListEl, -1);
+      coverImg.classList.add('hidden');
+      trackListEl.scrollTop = 0;
+      renderTrackList();
+      loadTrack(0);
+    }
+
     function loadPlaylist(i) {
       currentList = playlists[i].tracks;
       highlight(playlistListEl, i);
+      highlight(albumListEl, -1);
+      highlight(artistListEl, -1);
       coverImg.classList.add('hidden');
       trackListEl.scrollTop = 0;
       renderTrackList();
@@ -132,7 +164,7 @@
       trackListEl.innerHTML = "";
       currentList.forEach((t, idx) => {
         const li = document.createElement("li");
-        li.textContent = t.title;
+        li.textContent = `${t.title} – ${t.artist}`;
         li.className = "px-2 py-2 cursor-pointer hover:bg-black/5";
         li.onclick = () => loadTrack(idx);
         trackListEl.appendChild(li);
@@ -145,6 +177,7 @@
       if (!track) return;
       audioEl.src = track.src;
       highlight(trackListEl, i);
+      nowPlayingEl.textContent = `${track.title} – ${track.artist} (${track.album})`;
       if (isPlaying) audioEl.play();
     }
 
@@ -178,6 +211,7 @@
        Boot – called after catalog loads
     ========================================================= */
     function boot() {
+      renderArtists();
       renderAlbums();
       renderPlaylists();
     }

--- a/player/index.html
+++ b/player/index.html
@@ -19,18 +19,23 @@
   <h1 class="text-lg font-bold uppercase tracking-wide mb-6">No Label Player</h1>
 
   <div id="player" class="w-full max-w-lg bg-white border border-black p-6 shadow-sm">
+    <div id="browseNav" class="flex justify-center space-x-4 mb-4">
+      <button data-target="albums" class="px-2 py-1 border border-black active">Albums</button>
+      <button data-target="artists" class="px-2 py-1 border border-black">Artists</button>
+      <button data-target="playlists" class="px-2 py-1 border border-black">Playlists</button>
+    </div>
     <!-- lists -->
-    <ul id="artistList" class="artist-list mb-4 max-h-40 overflow-y-auto divide-y divide-black"></ul>
     <ul id="albumList" class="album-list mb-4 max-h-40 overflow-y-auto divide-y divide-black"></ul>
-    <ul id="playlistList" class="playlist-list mb-4 max-h-40 overflow-y-auto divide-y divide-black"></ul>
+    <ul id="artistList" class="artist-list mb-4 max-h-40 overflow-y-auto divide-y divide-black hidden"></ul>
+    <ul id="playlistList" class="playlist-list mb-4 max-h-40 overflow-y-auto divide-y divide-black hidden"></ul>
     <img id="coverImg" alt="Album cover" class="w-full mb-4 hidden" />
     <ul id="trackList" class="track-list max-h-56 overflow-y-auto divide-y divide-black"></ul>
 
     <!-- controls -->
     <div class="controls flex justify-center space-x-8 mt-4 mb-3">
-      <button id="prevBtn" aria-label="Previous track" class="p-1 hover:bg-black hover:text-white transition">⏮</button>
-      <button id="playPauseBtn" aria-label="Play / Pause" class="p-1 hover:bg-black hover:text-white transition">▶️</button>
-      <button id="nextBtn" aria-label="Next track" class="p-1 hover:bg-black hover:text-white transition">⏭</button>
+      <button id="prevBtn" aria-label="Previous track" class="p-1 hover:bg-black hover:text-white transition">Prev</button>
+      <button id="playPauseBtn" aria-label="Play / Pause" class="p-1 hover:bg-black hover:text-white transition">Play</button>
+      <button id="nextBtn" aria-label="Next track" class="p-1 hover:bg-black hover:text-white transition">Next</button>
     </div>
     <div id="nowPlaying" class="text-center mb-2"></div>
     <progress id="seekBar" value="0" max="100" aria-label="Playback position"></progress>
@@ -70,6 +75,7 @@
     const albumListEl = document.getElementById("albumList");
     const artistListEl = document.getElementById("artistList");
     const playlistListEl = document.getElementById("playlistList");
+    const navBtns = document.querySelectorAll('#browseNav button');
     const trackListEl = document.getElementById("trackList");
     const audioEl = document.getElementById("audio");
     const playPauseBtn = document.getElementById("playPauseBtn");
@@ -85,6 +91,17 @@
     let currentList = [];
     let currentIndex = 0;
     let isPlaying = false;
+
+    navBtns.forEach(btn => {
+      btn.onclick = () => {
+        navBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const target = btn.dataset.target;
+        albumListEl.classList.toggle('hidden', target !== 'albums');
+        artistListEl.classList.toggle('hidden', target !== 'artists');
+        playlistListEl.classList.toggle('hidden', target !== 'playlists');
+      };
+    });
 
     /* =========================================================
        Render helpers
@@ -104,7 +121,7 @@
       artistListEl.innerHTML = '';
       artists.forEach((artist, idx) => {
         const li = document.createElement('li');
-        li.textContent = '🎤 ' + artist.name;
+        li.textContent = artist.name;
         li.className = 'px-2 py-2 cursor-pointer hover:bg-black/5';
         li.onclick = () => loadArtist(idx);
         artistListEl.appendChild(li);
@@ -115,7 +132,7 @@
       playlistListEl.innerHTML = '';
       playlists.forEach((pl, idx) => {
         const li = document.createElement("li");
-        li.textContent = "★ " + pl.title;
+        li.textContent = pl.title;
         li.className = "px-2 py-2 cursor-pointer hover:bg-black/5";
         li.onclick = () => loadPlaylist(idx);
         playlistListEl.appendChild(li);
@@ -197,8 +214,8 @@
     prevBtn.onclick = () => currentIndex > 0 && loadTrack(currentIndex - 1);
     nextBtn.onclick = () => currentIndex < currentList.length - 1 && loadTrack(currentIndex + 1);
 
-    audioEl.onplay = () => { isPlaying = true; playPauseBtn.textContent = "⏸"; };
-    audioEl.onpause = () => { isPlaying = false; playPauseBtn.textContent = "▶️"; };
+    audioEl.onplay = () => { isPlaying = true; playPauseBtn.textContent = "Pause"; };
+    audioEl.onpause = () => { isPlaying = false; playPauseBtn.textContent = "Play"; };
     audioEl.ontimeupdate = () => { seekBar.value = (audioEl.currentTime / audioEl.duration) * 100 || 0; };
     audioEl.onended = () => nextBtn.click();
 
@@ -214,6 +231,7 @@
       renderArtists();
       renderAlbums();
       renderPlaylists();
+      if (albums.length) loadAlbum(0);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- build index with artists list and track metadata
- add artist list and now playing UI to player
- show artist, album and title when playing a track

## Testing
- `npm run build`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_686baf618b9483319e46a64a2d8fa46d