### PR TITLE
Add setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ repo-root/
 
 ```bash
 git clone <repo-url> && cd <repo>
-npm ci
-npm run dev            # builds catalog.json, serves site on http://localhost:8080
+npm run dev            # installs deps on first run, builds catalog.json, serves site on http://localhost:8080
 # (run from the repo root so /catalog is served)
+
+# or just set up dependencies and run checks
+# npm run setup
 
 # or run live-server manually from the repo root
 # npx live-server

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/build-index.mjs",
-    "dev":  "npm run build && npx live-server --open=",
+    "setup": "bash scripts/setup.sh",
+    "dev":  "npm run setup && npm run build && npx live-server --open=",
     "verify": "bash scripts/verify.sh"
   },
   "dependencies": {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Install dependencies and verify the catalog.
+set -euo pipefail
+
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm ci
+fi
+
+npm run verify


### PR DESCRIPTION
## Summary
- add setup.sh script
- run setup automatically from npm run dev
- document new workflow in README

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_6873c614a60c8331b7abf5036cc63da8